### PR TITLE
Make having a prefix optional

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -65,50 +65,54 @@ func statsd(c *StatsDConfig) error {
 
 	// for each metric in the registry format into statsd wireformat and send
 	c.Registry.Each(func(name string, metric interface{}) {
+		if c.Prefix != "" {
+			name = fmt.Sprintf("%s.%s", c.Prefix, name)
+		}
+
 		switch m := metric.(type) {
 		case metrics.Counter:
-			fmt.Fprintf(w, "%s--%s.count:%d|c\n", c.Prefix, name, m.Count())
+			fmt.Fprintf(w, "%s.count:%d|c\n", name, m.Count())
 		case metrics.Gauge:
-			fmt.Fprintf(w, "%s--%s.value:%d|g\n", c.Prefix, name, m.Value())
+			fmt.Fprintf(w, "%s.value:%d|g\n", name, m.Value())
 		case metrics.GaugeFloat64:
-			fmt.Fprintf(w, "%s--%s.value:%f|g\n", c.Prefix, name, m.Value())
+			fmt.Fprintf(w, "%s.value:%f|g\n", name, m.Value())
 		case metrics.Histogram:
 			h := m.Snapshot()
 			ps := h.Percentiles(c.Percentiles)
-			fmt.Fprintf(w, "%s--%s.count:%d|c\n", c.Prefix, name, h.Count())
-			fmt.Fprintf(w, "%s--%s.min:%d|g\n", c.Prefix, name, h.Min())
-			fmt.Fprintf(w, "%s--%s.max:%d|g\n", c.Prefix, name, h.Max())
-			fmt.Fprintf(w, "%s--%s.mean:%.2f|g\n", c.Prefix, name, h.Mean())
-			fmt.Fprintf(w, "%s--%s.std-dev:%.2f|g\n", c.Prefix, name, h.StdDev())
+			fmt.Fprintf(w, "%s.count:%d|c\n", name, h.Count())
+			fmt.Fprintf(w, "%s.min:%d|g\n", name, h.Min())
+			fmt.Fprintf(w, "%s.max:%d|g\n", name, h.Max())
+			fmt.Fprintf(w, "%s.mean:%.2f|g\n", name, h.Mean())
+			fmt.Fprintf(w, "%s.std-dev:%.2f|g\n", name, h.StdDev())
 			for psIdx, psKey := range c.Percentiles {
 				key := strings.Replace(strconv.FormatFloat(psKey*100.0, 'f', -1, 64), ".", "", 1)
-				fmt.Fprintf(w, "%s--%s.%s-percentile:%.2f|g\n", c.Prefix, name, key, ps[psIdx])
+				fmt.Fprintf(w, "%s.%s-percentile:%.2f|g\n", name, key, ps[psIdx])
 			}
 		case metrics.Meter:
 			ss := m.Snapshot()
-			fmt.Fprintf(w, "%s--%s.count:%d|c\n", c.Prefix, name, ss.Count())
-			fmt.Fprintf(w, "%s--%s.one-minute:%.2f|g\n", c.Prefix, name, ss.Rate1())
-			fmt.Fprintf(w, "%s--%s.five-minute:%.2f|g\n", c.Prefix, name, ss.Rate5())
-			fmt.Fprintf(w, "%s--%s.fifteen-minute:%.2f|g\n", c.Prefix, name, ss.Rate15())
-			fmt.Fprintf(w, "%s--%s.mean:%.2f|g\n", c.Prefix, name, ss.RateMean())
+			fmt.Fprintf(w, "%s.count:%d|c\n", name, ss.Count())
+			fmt.Fprintf(w, "%s.one-minute:%.2f|g\n", name, ss.Rate1())
+			fmt.Fprintf(w, "%s.five-minute:%.2f|g\n", name, ss.Rate5())
+			fmt.Fprintf(w, "%s.fifteen-minute:%.2f|g\n", name, ss.Rate15())
+			fmt.Fprintf(w, "%s.mean:%.2f|g\n", name, ss.RateMean())
 		case metrics.Timer:
 			t := m.Snapshot()
 			ps := t.Percentiles(c.Percentiles)
-			fmt.Fprintf(w, "%s--%s.count:%d|c\n", c.Prefix, name, t.Count())
-			fmt.Fprintf(w, "%s--%s.min:%d|g\n", c.Prefix, name, t.Min()/int64(du))
-			fmt.Fprintf(w, "%s--%s.max:%d|g\n", c.Prefix, name, t.Max()/int64(du))
-			fmt.Fprintf(w, "%s--%s.mean:%.2f|g\n", c.Prefix, name, t.Mean()/du)
-			fmt.Fprintf(w, "%s--%s.std-dev:%.2f|g\n", c.Prefix, name, t.StdDev()/du)
+			fmt.Fprintf(w, "%s.count:%d|c\n", name, t.Count())
+			fmt.Fprintf(w, "%s.min:%d|g\n", name, t.Min()/int64(du))
+			fmt.Fprintf(w, "%s.max:%d|g\n", name, t.Max()/int64(du))
+			fmt.Fprintf(w, "%s.mean:%.2f|g\n", name, t.Mean()/du)
+			fmt.Fprintf(w, "%s.std-dev:%.2f|g\n", name, t.StdDev()/du)
 			for psIdx, psKey := range c.Percentiles {
 				key := strings.Replace(strconv.FormatFloat(psKey*100.0, 'f', -1, 64), ".", "", 1)
-				fmt.Fprintf(w, "%s--%s.%s-percentile:%.2f|g\n", c.Prefix, name, key, ps[psIdx]/du)
+				fmt.Fprintf(w, "%s.%s-percentile:%.2f|g\n", name, key, ps[psIdx]/du)
 			}
-			fmt.Fprintf(w, "%s--%s.one-minute:%.2f|g\n", c.Prefix, name, t.Rate1())
-			fmt.Fprintf(w, "%s--%s.five-minute:%.2f|g\n", c.Prefix, name, t.Rate5())
-			fmt.Fprintf(w, "%s--%s.fifteen-minute:%.2f|g\n", c.Prefix, name, t.Rate15())
-			fmt.Fprintf(w, "%s--%s.mean-rate:%.2f|g\n", c.Prefix, name, t.RateMean())
+			fmt.Fprintf(w, "%s.one-minute:%.2f|g\n", name, t.Rate1())
+			fmt.Fprintf(w, "%s.five-minute:%.2f|g\n", name, t.Rate5())
+			fmt.Fprintf(w, "%s.fifteen-minute:%.2f|g\n", name, t.Rate15())
+			fmt.Fprintf(w, "%s.mean-rate:%.2f|g\n", name, t.RateMean())
 		default:
-			log.Println("[WARN] No Metric", c.Prefix, name, reflect.TypeOf(m))
+			log.Println("[WARN] No Metric", name, reflect.TypeOf(m))
 		}
 		w.Flush()
 	})


### PR DESCRIPTION
Not every user requires one. Also, change the separator between the prefix and the metric name to be a single `.` to follow common statsd naming conventions.